### PR TITLE
Add BASE_URL to allow hosting under subpaths

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,3 +13,11 @@ curl -fF "images.txt=@images.txt" localhost:8080/tar > images.tar
 # OR
 wget 'localhost:8080/tar?image=hello-world&image=busybox' -O images.tar
 ```
+
+## FAQ
+
+### Hosting Under a Subpath
+
+The `BASE_URL` environment variable allows hosting under a subpath.
+
+If the value of `BASE_URL` is `/saveomat` the image request becomes `localhost:8080/saveomat/tar`.

--- a/internal/pkg/server/index.html.go
+++ b/internal/pkg/server/index.html.go
@@ -9,7 +9,7 @@ const indexHTML = `<!doctype html>
 <body>
 <h2>Upload images.txt file</h2>
 
-<form action="./tar" method="post" enctype="multipart/form-data">
+<form action="tar" method="post" enctype="multipart/form-data">
     Images file: <input type="file" name="images.txt"><br><br>
     <input type="submit" value="Submit">
 </form>

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -15,24 +15,31 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
+type ServerOpts struct {
+	BaseURL      string
+	DockerClient client.ImageAPIClient
+}
+
 type Server struct {
 	*echo.Echo
 	DockerClient client.ImageAPIClient
 }
 
-func NewServer(c client.ImageAPIClient) *Server {
+func NewServer(opt ServerOpts) *Server {
 	e := echo.New()
-	s := &Server{e, c}
+	s := &Server{e, opt.DockerClient}
 
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	e.Use(middleware.BodyLimit("512K"))
 
-	e.GET("/", func(c echo.Context) error {
+	baseurl := strings.TrimSuffix(opt.BaseURL, "/")
+	g := e.Group(baseurl)
+	g.GET("/", func(c echo.Context) error {
 		return c.HTML(http.StatusOK, indexHTML)
 	})
-	e.POST("/tar", s.postTar)
-	e.GET("/tar", s.getTar)
+	g.POST("/tar", s.postTar)
+	g.GET("/tar", s.getTar)
 
 	return s
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/bastjan/saveomat/internal/pkg/server"
 	"github.com/docker/docker/client"
 )
@@ -11,6 +13,10 @@ func main() {
 		panic("Could not initialize docker client.")
 	}
 
-	e := server.NewServer(cli)
+	e := server.NewServer(server.ServerOpts{
+		DockerClient: cli,
+		BaseURL:      os.Getenv("BASE_URL"),
+	})
+
 	e.Logger.Fatal(e.Start(":8080"))
 }


### PR DESCRIPTION
Adds a `BASE_URL` environment variable to allow hosting under a sub-path.

`BASE_URL=/saveomat` => `curl localhost:8080/saveomat/tar`